### PR TITLE
Modernise snapcraft.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,7 +24,8 @@ parts:
     plugin: python
     source: .
     parse-info: [setup.py]
-    requirements: requirements.txt
+    requirements:
+      - requirements.txt
     build-packages:
       - libffi-dev
     stage-packages:


### PR DESCRIPTION
- with explicit base, requirements syntax changed.
- Put it in snap/snapcraft.yaml.