### PR TITLE
Bump version number. Move to libsodium23.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="surl",
-    version="0.7.3",
+    version="0.8.0",
     author="Celso Providelo",
     author_email="celso.providelo@canonical.com",
     url="https://github.com/cprov/surl",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,7 +29,7 @@ parts:
     build-packages:
       - libffi-dev
     stage-packages:
-      - libsodium18
+      - libsodium23
       - libsodium-dev
     python-packages:
       - tabulate


### PR DESCRIPTION
the old libsodium18 is not available on ubuntu 20.04.

The version number bump is not strictly needed but nice to signify all the recent changes, particularly depending on core20 for the snap (though installing from source should work on older systems) and candid support.