### PR TITLE
Fix app paths

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,16 +7,16 @@ base: core20
 
 apps:
   surl:
-    command: usr/bin/python3 -u $SNAP/bin/surl_cli.py
+    command: bin/surl_cli.py
     plugs: [network-bind, network]
   metrics:
-    command: usr/bin/python3 -u $SNAP/bin/surl_metrics.py
+    command: bin/surl_metrics.py
     plugs: [network-bind, network]
   storeops:
-    command: usr/bin/python3 -u $SNAP/bin/surl_storeops.py
+    command: bin/surl_storeops.py
     plugs: [network-bind, network]
   monthinsnaps:
-    command: usr/bin/python3 -u $SNAP/bin/surl_month_in_snaps.py
+    command: bin/surl_month_in_snaps.py
     plugs: [network-bind, network]
 
 parts:


### PR DESCRIPTION
The old ones were probably ancient and don't work anymore when building for core20.